### PR TITLE
Fix tracking of column numbers when a regex is tokenized.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ impl<'b> Scanner<'b> {
             };
             match next.ty {
                 RawToken::RegEx(body_end) => {
-                    self.line_cursor = self.line_cursor.saturating_add(len);
+                    self.line_cursor = self.line_cursor.saturating_add(next.end - next.start);
                     let flags = if next.end > body_end {
                         Some(&self.original[body_end..next.end])
                     } else {

--- a/tests/snippets/main.rs
+++ b/tests/snippets/main.rs
@@ -287,9 +287,34 @@ fn long_comment() {
     )
 }
 
+#[test]
+fn regex_column() {
+    compare_with_position(
+        "'abc'.match(/abc/);",
+        &[
+            (Token::String(StringLit::single("abc", false)), 1, 1),
+            (Token::Punct(Punct::Period), 1, 6),
+            (Token::Ident("match".into()), 1, 7),
+            (Token::Punct(Punct::OpenParen), 1, 12),
+            (Token::RegEx(RegEx::from_parts("abc", None)), 1, 13),
+            (Token::Punct(Punct::CloseParen), 1, 18),
+            (Token::Punct(Punct::SemiColon), 1, 19),
+        ],
+    );
+}
+
 fn compare(js: &str, expectation: &[Token<&str>]) {
     for (i, (par, ex)) in panicing_scanner(js).zip(expectation.iter()).enumerate() {
         assert_eq!((i, &par), (i, ex));
+    }
+}
+
+fn compare_with_position(js: &str, expectation: &[(Token<&str>, usize, usize)]) {
+    let scanner = Scanner::new(js).map(|r| r.unwrap());
+    for (i, (r, ex)) in scanner.zip(expectation.iter()).enumerate() {
+        assert_eq!((i, &r.token), (i, &ex.0));
+        assert_eq!((i, r.location.start.line), (i, ex.1));
+        assert_eq!((i, r.location.start.column), (i, ex.2));
     }
 }
 


### PR DESCRIPTION
The code was adding 'len' to the column number, but that only accounts for the
opening '/'. We need to add the entire length of the regex.