### PR TITLE
Fix bug in line cursor positioning when parsing template literals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ress"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Robert Masen <r@robertmasen.pizza>"]
 description = "A scanner/tokenizer for JS files"
 keywords = ["JavaScript", "parsing", "JS", "ES", "ECMA"]

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -842,6 +842,7 @@ impl<'a> Tokenizer<'a> {
             } else if c == '$' {
                 if self.look_ahead_byte_matches('{') {
                     self.stream.skip_bytes(1);
+                    last_len = last_len.saturating_add(1);
                     self.curly_stack.push(OpenCurlyKind::Template);
                     if start == '`' {
                         return self.gen_template(

--- a/tests/snippets/main.rs
+++ b/tests/snippets/main.rs
@@ -341,8 +341,20 @@ fn compare_with_position(js: &str, expectation: &[(Token<&str>, usize, usize)]) 
     let scanner = Scanner::new(js).map(|r| r.unwrap());
     for (i, (r, ex)) in scanner.zip(expectation.iter()).enumerate() {
         assert_eq!((i, &r.token), (i, &ex.0), "{:?} vs {:?}", r, ex.0);
-        assert_eq!((i, r.location.start.line), (i, ex.1), "{:?} vs {:?}", r, ex.0);
-        assert_eq!((i, r.location.start.column), (i, ex.2), "{:?} vs {:?}", r, ex.0);
+        assert_eq!(
+            (i, r.location.start.line),
+            (i, ex.1),
+            "{:?} vs {:?}",
+            r,
+            ex.0
+        );
+        assert_eq!(
+            (i, r.location.start.column),
+            (i, ex.2),
+            "{:?} vs {:?}",
+            r,
+            ex.0
+        );
     }
 }
 


### PR DESCRIPTION
Fix a bug that was causing template parsing to report the wrong source location