### PR TITLE
account for skipped whitespace in regex

### DIFF
--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -395,6 +395,7 @@ pub enum Punct {
     TripleGreaterThanEqual,
     TripleGreaterThan,
 }
+
 impl PartialEq<str> for Punct {
     fn eq(&self, other: &str) -> bool {
         self.matches_str(other)


### PR DESCRIPTION
Previously when we were calculating a regex's position w/o accounting for the previously skipped whitspace