### PR TITLE
Fix end length calculation for regex with leading whitespace

### DIFF
--- a/src/manual_scanner.rs
+++ b/src/manual_scanner.rs
@@ -267,6 +267,9 @@ impl<'b> ManualScanner<'b> {
 
     fn next_regex_item(&mut self, prev_len: usize) -> Res<Item<&'b str>> {
         self.stream.stream.skip_back(self.last_skipped_whitespace);
+        self.line_cursor = self
+            .line_cursor
+            .saturating_sub(self.last_skipped_whitespace);
         let (_, prev_lines, prev_line_cursor) = self.capture_cursors();
         let next = match self.stream.next_regex(prev_len) {
             Ok(n) => n,
@@ -290,14 +293,13 @@ impl<'b> ManualScanner<'b> {
                     next.start,
                     next.end,
                     prev_lines + 1,
-                    prev_line_cursor.saturating_sub(prev_len + self.last_skipped_whitespace),
+                    prev_line_cursor.saturating_sub(prev_len),
                     prev_lines + 1,
                     self.line_cursor,
                 )
             }
             _ => {
-                todo!();
-                // Some(self.error(todo!()))
+                unreachable!();
             }
         };
         let (new_line_count, leading_whitespace) = self.stream.skip_whitespace();

--- a/tests/snippets/main.rs
+++ b/tests/snippets/main.rs
@@ -353,6 +353,27 @@ fn regex_out_of_order() {
 }
 
 #[test]
+fn regex_pattern() {
+    pretty_env_logger::try_init().ok();
+    let re = r#" \{[\s\S]*$"#;
+    let js = format!("/{re}/");
+
+    let mut scanner = Scanner::new(&js);
+    let Item {
+        location,
+        token: Token::RegEx(re2),
+        ..
+    } = scanner.next().unwrap().unwrap() else {
+        panic!("Expected regex");
+    };
+    assert_eq!(location.start.line, 1);
+    assert_eq!(location.end.line, 1);
+    assert_eq!(location.start.column, 1);
+    assert_eq!(re2.body, re);
+    assert_eq!(location.end.column, re.len() + 3);
+}
+
+#[test]
 fn regex_over_a0() {
     let js = r#"val = / /"#;
     compare(


### PR DESCRIPTION
Regex literal parsing was incorrectly reporting the end position by the number of tokens equal to any leading white space.